### PR TITLE
Add defaultManager to SwiftyGifManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ You can furthermore set a specific number of loops to your gif via `loopTime`. D
 self.myImageView.setGifImage(gif, manager: gifManager, loopTime:2)// The gif will loop 2 times
 ```
 
+######Default Manager	
+If you want, you can ommit the `manager` parameter `UIImageView` methods. By default, it will use the `SwiftyGifManager.defaultManager`. 
+
+
 ##Benchmark
 ###Display 1 Image
 |               |CPU Usage(average) |Memory Usage(average) |

--- a/SwiftyGif/SwiftyGifManager.swift
+++ b/SwiftyGif/SwiftyGifManager.swift
@@ -8,6 +8,8 @@ import Foundation
 
 public class SwiftyGifManager {
 
+    static var defaultManager = SwiftyGifManager(memoryLimit: 20)
+    
     private var timer: CADisplayLink?
     private var displayViews: [UIImageView] = []
     private var totalGifSize: Int

--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -19,21 +19,21 @@ public extension UIImageView {
 
     // PRAGMA - Inits
 
-    public convenience init(gifImage:UIImage, manager:SwiftyGifManager) {
+    public convenience init(gifImage:UIImage, manager:SwiftyGifManager = SwiftyGifManager.defaultManager) {
         self.init()
         setGifImage(gifImage,manager: manager,loopTime: -1);
     }
 
-    public convenience init(gifImage:UIImage, manager:SwiftyGifManager, loopTime:Int) {
+    public convenience init(gifImage:UIImage, manager:SwiftyGifManager = SwiftyGifManager.defaultManager, loopTime:Int) {
         self.init()
         setGifImage(gifImage,manager: manager,loopTime: loopTime);
     }
 
-    public func setGifImage(gifImage:UIImage, manager:SwiftyGifManager) {
+    public func setGifImage(gifImage:UIImage, manager:SwiftyGifManager = SwiftyGifManager.defaultManager) {
         setGifImage(gifImage, manager: manager, loopTime: -1)
     }
 
-    public func setGifImage(gifImage:UIImage, manager:SwiftyGifManager, loopTime:Int) {
+    public func setGifImage(gifImage:UIImage, manager:SwiftyGifManager = SwiftyGifManager.defaultManager, loopTime:Int) {
 
         self.loopTime = loopTime
         self.gifImage = gifImage


### PR DESCRIPTION
Hey, 

I think it would be easier if we had a `defaultManager` on `SwiftyGifManager` (especially when you just have only one `gif` to display). 
