### PR TITLE
Master

### DIFF
--- a/SwiftyGif/UIImage+SwiftyGif.swift
+++ b/SwiftyGif/UIImage+SwiftyGif.swift
@@ -199,6 +199,10 @@ public extension UIImage{
                 }
             }
             
+            if(displayPosition[0] == 0){
+                framelosecount += 1
+            }
+            
             if framelosecount <= Float(displayPosition.count) * (1.0 - levelOfIntegrity) ||
                 i == displayRefreshDelayTime.count-1 {
                 

--- a/SwiftyGif/UIImage+SwiftyGif.swift
+++ b/SwiftyGif/UIImage+SwiftyGif.swift
@@ -199,10 +199,6 @@ public extension UIImage{
                 }
             }
             
-            if(displayPosition[0] == 0){
-                framelosecount += 1
-            }
-            
             if framelosecount <= Float(displayPosition.count) * (1.0 - levelOfIntegrity) ||
                 i == displayRefreshDelayTime.count-1 {
                 


### PR DESCRIPTION
I had an issue with gifs of 2 frames not updating and only showing the
2nd frame. I think it’s because it’s not counting the 1st frame as lose
when the display index is 0 which is never shown.