### PR TITLE
Fix #34

### DIFF
--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -253,7 +253,7 @@ public extension UIImageView {
         }
         
         let screenRect = UIScreen.main.bounds
-        let viewRect = imageView!.convert(self.frame, to:nil)
+        let viewRect = imageView!.convert(self.bounds, to:nil)
         
         let intersectionRect = viewRect.intersection(screenRect);
         if (intersectionRect.isEmpty || intersectionRect.isNull) {


### PR DESCRIPTION
As `frame` describes the location of the view within its superview, when it is converted to the location within the window, the location might be outside the window view. That's why it stops playing even when the view is still being displayed on the window

