### PR TITLE
Remove force casting from extensions

### DIFF
--- a/SwiftyGif/UIImage+SwiftyGif.swift
+++ b/SwiftyGif/UIImage+SwiftyGif.swift
@@ -294,7 +294,7 @@ public extension UIImage {
             if result == nil {
                 return nil
             }
-            return (result as! CGImageSource)
+            return (result as? CGImageSource)
         }
         set {
             objc_setAssociatedObject(self, _imageSourceKey!, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN);

--- a/SwiftyGif/UIImage+SwiftyGif.swift
+++ b/SwiftyGif/UIImage+SwiftyGif.swift
@@ -294,7 +294,7 @@ public extension UIImage {
             if result == nil {
                 return nil
             }
-            return (result as? CGImageSource)
+            return (result as! CGImageSource)
         }
         set {
             objc_setAssociatedObject(self, _imageSourceKey!, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN);

--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -389,7 +389,7 @@ public extension UIImageView {
     
     public var delegate: SwiftyGifDelegate? {
         get {
-            return (objc_getAssociatedObject(self, _delegateKey!) as? SwiftyGifDelegate?)
+            return (objc_getAssociatedObject(self, _delegateKey!) as? SwiftyGifDelegate)
         }
         set {
             objc_setAssociatedObject(self, _delegateKey!, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN);

--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -331,7 +331,7 @@ public extension UIImageView {
         if result == nil {
             return nil
         }
-        return (result as! T)
+        return (result as? T)
     }
 
     public var gifImage: UIImage? {
@@ -389,7 +389,7 @@ public extension UIImageView {
     
     public var delegate: SwiftyGifDelegate? {
         get {
-            return (objc_getAssociatedObject(self, _delegateKey!) as! SwiftyGifDelegate?)
+            return (objc_getAssociatedObject(self, _delegateKey!) as? SwiftyGifDelegate?)
         }
         set {
             objc_setAssociatedObject(self, _delegateKey!, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN);
@@ -432,7 +432,7 @@ public extension UIImageView {
     
     fileprivate var cache: NSCache<AnyObject, AnyObject>? {
         get {
-            return (objc_getAssociatedObject(self, _cacheKey!) as! NSCache)
+            return (objc_getAssociatedObject(self, _cacheKey!) as? NSCache)
         }
         set {
             objc_setAssociatedObject(self, _cacheKey!, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN);


### PR DESCRIPTION
I was seeing a crash when calling `clear()` on `UIImageView` that was being caused by this force unwrapping. 