### PR TITLE
Avoid race condition when stopping gif animation and reusing UIImageView

### DIFF
--- a/SwiftyGif/SwiftyGifManager.swift
+++ b/SwiftyGif/SwiftyGifManager.swift
@@ -114,7 +114,9 @@ open class SwiftyGifManager {
         for imageView in displayViews {
 
             DispatchQueue.main.async{
-                imageView.image = imageView.currentImage
+                if imageView.isAnimatingGif() {
+                    imageView.image = imageView.currentImage
+                }
             }
             if imageView.isAnimatingGif() {
                 DispatchQueue.global(qos: DispatchQoS.QoSClass.userInteractive).sync{


### PR DESCRIPTION
There was a race condition when trying to reusing UIImageView that was showing
animated gif and setting it to display a static image instead. Stopping gif
with `stopAnimatingGif` wasn't applied immediately, it was possible that next
frame will be set on the next tick due to async call to the main thread.

We hit this when using UIImageView with animated gif in UITableViewCell:

1. we set animated gif and start animating

2. prepareForReuse is called and we call `imageView.stopAnimatingGif` and
`SwiftyGifManager.defaultManager.deleteImageView(imageView)` and
`imageView.image = nil`

3. cell gets reused and we set a different image (regular image, not a gif).

4. that async call from `updateImageView` set a frame of the gif overriding our
image.