### PR TITLE
Sets gif image before calling to delegate making the image available …

### DIFF
--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -129,8 +129,8 @@ public extension UIImageView {
             DispatchQueue.main.async {
                 loader.removeFromSuperview()
                 if let data = data {
-                    self.delegate?.gifURLDidFinish?(sender: self)
                     self.setGifImage(UIImage.init(gifData: data), manager: manager, loopCount: loopCount)
+                    self.delegate?.gifURLDidFinish?(sender: self)
                 } else {
                     self.delegate?.gifURLDidFail?(sender: self)
                 }


### PR DESCRIPTION
…from the UIImageView sender

# Description

Using `sender.gifImage` in the `gifURLDidFinish(sender: UIImageView)` delegate function shows the `gifImage` to be `nil`. This is a bit troublesome if you need to do something with the image.