### PR TITLE
add s.swift_version = '4.2' to podspec

### DIFF
--- a/SwiftyGif.podspec
+++ b/SwiftyGif.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.requires_arc = true
   s.source_files = 'SwiftyGif/*{.h,.swift}'
+  s.swift_version = '4.2'
 end


### PR DESCRIPTION
why many the pod repos did not use swift_version? 
https://github.com/UrbanApps/Armchair/pull/123