### PR TITLE
Change delegate to OBJC_ASSOCIATION_ASSIGN

### DIFF
--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -435,7 +435,7 @@ public extension UIImageView {
             return (objc_getAssociatedObject(self, _delegateKey!) as? SwiftyGifDelegate)
         }
         set {
-            objc_setAssociatedObject(self, _delegateKey!, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            objc_setAssociatedObject(self, _delegateKey!, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN);
         }
     }
     


### PR DESCRIPTION
To break the retain cycle

Issue: https://github.com/kirualex/SwiftyGif/issues/84