### PR TITLE
Allow specifying a custom URLSession

### DIFF
--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -100,11 +100,12 @@ public extension UIImageView {
                        manager: SwiftyGifManager = .defaultManager,
                        loopCount: Int = -1,
                        levelOfIntegrity: GifLevelOfIntegrity = .default,
+                       session: URLSession = URLSession.shared,
                        showLoader: Bool = true) -> URLSessionDataTask {
         stopAnimatingGif()
         let loader: UIActivityIndicatorView? = showLoader ? createLoader() : nil
         
-        let task = URLSession.shared.dataTask(with: url) { data, _, error in
+        let task = session.dataTask(with: url) { data, _, error in
             DispatchQueue.main.async {
                 loader?.removeFromSuperview()
                 self.parseDownloadedGif(url: url,


### PR DESCRIPTION
For instance, to customize HTTP headers’ user agent or add authentication tokens.