### PR TITLE
method "gifDidStop" will execute twice"

### DIFF
--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -459,8 +459,6 @@ public extension UIImageView {
             
             if newValue {
                 delegate?.gifDidStart?(sender: self)
-            } else {
-                delegate?.gifDidStop?(sender: self)
             }
         }
     }


### PR DESCRIPTION
fix "if I use function "setGifFromURL:" method "gifDidStop" will execute twice"