### PR TITLE
Fix: Crash when gif loaded from url and delegate has been deallocated

### DIFF
--- a/SwiftyGif/NSImageView+SwiftyGif.swift
+++ b/SwiftyGif/NSImageView+SwiftyGif.swift
@@ -120,10 +120,10 @@ public extension NSImageView {
         
         let loader: NSView? = showLoader ? createLoader(from: customLoader) : nil
         
-        let task = session.dataTask(with: url) { data, _, error in
+        let task = session.dataTask(with: url) { [weak self] data, _, error in
             DispatchQueue.main.async {
                 loader?.removeFromSuperview()
-                self.parseDownloadedGif(url: url,
+                self?.parseDownloadedGif(url: url,
                                         data: data,
                                         error: error,
                                         manager: manager,

--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -120,10 +120,10 @@ public extension UIImageView {
         
         let loader: UIView? = showLoader ? createLoader(from: customLoader) : nil
         
-        let task = session.dataTask(with: url) { data, _, error in
+        let task = session.dataTask(with: url) { [weak self] data, _, error in
             DispatchQueue.main.async {
                 loader?.removeFromSuperview()
-                self.parseDownloadedGif(url: url,
+                self?.parseDownloadedGif(url: url,
                                         data: data,
                                         error: error,
                                         manager: manager,


### PR DESCRIPTION
### Description
Hello 👋 
First of all, thank you for open sourcing this library 🙂 

We have some customers reporting this crash, and we were able to reproduce it and fix it 🙂 Here is the crash log:
[Crash.txt](https://github.com/kirualex/SwiftyGif/files/7587968/Crash.txt)

### How to reproduce
It is a bit hard to reproduce this one. In our case, this happens because sometimes we make a call to `setGifFromURL` right before the view is deallocated. So one way to try and reproduce this is to call `setGifFromURL` on a `deinit` lifecycle of an object.

### Cause
The `URLSession` completion block retains self which prolongs the image view lifetime even if its `superview` and delegate have been deallocated already. When accessing the unsafe delegate, the app crashes.

### Solution
By not retaining self on the `URLSession` completion block, and weakly referencing it, it won't crash. I noticed that the same is happening on NSImageView so I applied the same fix.