### PR TITLE
Fix: objc_getAssociatedObject crashing on weak reference

### DIFF
--- a/SwiftyGif.xcodeproj/project.pbxproj
+++ b/SwiftyGif.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		3B18BB011E2898A1009C125A /* SwiftyGifManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE121E11CB2A3DD00960D00 /* SwiftyGifManager.swift */; };
 		3B18BB021E2898A5009C125A /* UIImage+SwiftyGif.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE121E21CB2A3DD00960D00 /* UIImage+SwiftyGif.swift */; };
 		3B18BB031E2898A9009C125A /* UIImageView+SwiftyGif.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE121E31CB2A3DD00960D00 /* UIImageView+SwiftyGif.swift */; };
+		AD938875276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD938874276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift */; };
+		AD938876276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD938874276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift */; };
 		EF34CB4D22A51591002A6C92 /* SwiftyGifTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF34CB4C22A51591002A6C92 /* SwiftyGifTests.swift */; };
 		EF34CB4F22A51591002A6C92 /* SwiftyGif.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B18BAF41E289899009C125A /* SwiftyGif.framework */; };
 		EF34CB5522A524F6002A6C92 /* single_frame_Zt2012.gif in Resources */ = {isa = PBXBuildFile; fileRef = EF26CB8A22A167B100E92383 /* single_frame_Zt2012.gif */; };
@@ -113,6 +115,7 @@
 		3B18BAF41E289899009C125A /* SwiftyGif.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyGif.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B18BAF61E289899009C125A /* SwiftyGif.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftyGif.h; sourceTree = "<group>"; };
 		3B18BAF71E289899009C125A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AD938874276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcAssociatedWeakObject.swift; sourceTree = "<group>"; };
 		EF26CB8822A166E400E92383 /* no_property_dictionary.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = no_property_dictionary.gif; sourceTree = "<group>"; };
 		EF26CB8A22A167B100E92383 /* single_frame_Zt2012.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = single_frame_Zt2012.gif; sourceTree = "<group>"; };
 		EF26CB8C22A16DB900E92383 /* 20000x20000.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = 20000x20000.gif; sourceTree = "<group>"; };
@@ -302,6 +305,7 @@
 				FAE121E31CB2A3DD00960D00 /* UIImageView+SwiftyGif.swift */,
 				230188A424D961CD00EFE1BC /* NSImage+SwiftyGif.swift */,
 				230188A224D9614900EFE1BC /* NSImageView+SwiftyGif.swift */,
+				AD938874276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift */,
 			);
 			path = SwiftyGif;
 			sourceTree = "<group>";
@@ -544,6 +548,7 @@
 			files = (
 				230188A124D95CB800EFE1BC /* SwiftyGifManager.swift in Sources */,
 				230188A524D961D800EFE1BC /* NSImage+SwiftyGif.swift in Sources */,
+				AD938876276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift in Sources */,
 				230188A324D9615700EFE1BC /* NSImageView+SwiftyGif.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -563,6 +568,7 @@
 			files = (
 				3B18BB021E2898A5009C125A /* UIImage+SwiftyGif.swift in Sources */,
 				3B18BB031E2898A9009C125A /* UIImageView+SwiftyGif.swift in Sources */,
+				AD938875276BBDBD00013AB1 /* ObjcAssociatedWeakObject.swift in Sources */,
 				3B18BB011E2898A1009C125A /* SwiftyGifManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftyGif/NSImageView+SwiftyGif.swift
+++ b/SwiftyGif/NSImageView+SwiftyGif.swift
@@ -441,8 +441,8 @@ public extension NSImageView {
     }
     
     var delegate: SwiftyGifDelegate? {
-        get { return (objc_getAssociatedObject(self, _delegateKey!) as? SwiftyGifDelegate) }
-        set { objc_setAssociatedObject(self, _delegateKey!, newValue, .OBJC_ASSOCIATION_ASSIGN) }
+        get { return (objc_getAssociatedWeakObject(self, _delegateKey!) as? SwiftyGifDelegate) }
+        set { objc_setAssociatedWeakObject(self, _delegateKey!, newValue) }
     }
     
     private var haveCache: Bool {

--- a/SwiftyGif/ObjcAssociatedWeakObject.swift
+++ b/SwiftyGif/ObjcAssociatedWeakObject.swift
@@ -1,0 +1,18 @@
+//
+//  ObjcAssociatedWeakObject.swift
+//
+
+import Foundation
+
+func objc_getAssociatedWeakObject(_ object: AnyObject, _ key: UnsafeRawPointer) -> AnyObject? {
+    let block: (() -> AnyObject?)? = objc_getAssociatedObject(object, key) as? (() -> AnyObject?)
+    return block != nil ? block?() : nil
+}
+
+func objc_setAssociatedWeakObject(_ object: AnyObject, _ key: UnsafeRawPointer, _ value: AnyObject?) {
+    weak var weakValue = value
+    let block: (() -> AnyObject?)? = {
+        return weakValue
+    }
+    objc_setAssociatedObject(object, key, block, .OBJC_ASSOCIATION_COPY)
+}

--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -436,8 +436,8 @@ public extension UIImageView {
     }
     
     var delegate: SwiftyGifDelegate? {
-        get { return (objc_getAssociatedObject(self, _delegateKey!) as? SwiftyGifDelegate) }
-        set { objc_setAssociatedObject(self, _delegateKey!, newValue, .OBJC_ASSOCIATION_ASSIGN) }
+        get { return (objc_getAssociatedWeakObject(self, _delegateKey!) as? SwiftyGifDelegate) }
+        set { objc_setAssociatedWeakObject(self, _delegateKey!, newValue) }
     }
     
     private var haveCache: Bool {


### PR DESCRIPTION
### Description
It looks that the previous fix: https://github.com/kirualex/SwiftyGif/pull/158 didn't actually fix the root of the problem. After more investigation, it seems the issue is related to `objc_associatedObject` API. The `OBJC_ASSOCIATION_ASSIGN` does not weakify references. More details about the issue can be found here: https://stackoverflow.com/questions/16569840/using-objc-setassociatedobject-with-weak-references

### How to reproduce
This can actually be easily reproducible on a Playground:
```swift
import UIKit

private let _delegateKey = malloc(4)

@objc protocol SwiftyGifDelegate: AnyObject { }
class SomeObject: SwiftyGifDelegate { }

extension UIImageView {
    var delegate: SwiftyGifDelegate? {
        get { return objc_getAssociatedObject(self, _delegateKey!) as? SwiftyGifDelegate }
        set { objc_setAssociatedObject(self, _delegateKey!, newValue, .OBJC_ASSOCIATION_ASSIGN) }
    }
}

let imageView = UIImageView()

autoreleasepool {
    let object = SomeObject()
    imageView.delegate = object
}

debugPrint(imageView.delegate)
```
Calling the `debugPrint(imageView.delegate)` will crash.

### Solution
Introduce a `objc_setAssociatedWeakObject` and `objc_getAssociatedWeakObject` to avoid the crash.  Instead of using the `OBJC_ASSOCIATION_ASSIGN` with the pointer directly, we use a block that stores a weak reference, and then use `OBJC_ASSOCIATION_COPY` for the block.

On the playground, if you replace the previous methods with the new ones, you will see that it doesn't crash anymore when accessing the `nil` delegate.