### PR TITLE
fix memory leak when imageView removed after stopAnimatingGif

### DIFF
--- a/SwiftyGif/SwiftyGifManager.swift
+++ b/SwiftyGif/SwiftyGifManager.swift
@@ -167,6 +167,10 @@ open class SwiftyGifManager {
             
             if imageView.isAnimatingGif() {
                 queue.sync(execute: imageView.updateCurrentImage)
+            } else if imageView.isDiscarded(imageView) {
+                queue.sync {
+                    self.deleteImageView(imageView)
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes
- added logic that deletes discarded view to SwiftyGifManager.updateImageView
## Description
fixes memory leak for imageView that has been set gif image and stopped animating gif
(the imageView was retained by manager even after being deleted from the hierarchy)