### PR TITLE
Support devices with a 120Hz screen

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SwiftyGif/NSImage+SwiftyGif.swift
+++ b/SwiftyGif/NSImage+SwiftyGif.swift
@@ -211,7 +211,7 @@ public extension NSImage {
         var delays = delaysArray
         
         // Factors send to CADisplayLink.frameInterval
-        let displayRefreshFactors = [60, 30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1]
+        let displayRefreshFactors = [120, 60, 30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1]
         
         // maxFramePerSecond,default is 60
         let maxFramePerSecond = displayRefreshFactors[0]


### PR DESCRIPTION
Simply adds 120 to the array of possible frame rates. Fixes #170, verified that GIF animates at correct speed on a 2021 14" MBP (120Hz screen)