### PR TITLE
Fix GIF pausing when on secondary display

### DIFF
--- a/SwiftyGif/NSImageView+SwiftyGif.swift
+++ b/SwiftyGif/NSImageView+SwiftyGif.swift
@@ -326,15 +326,22 @@ public extension NSImageView {
     ///
     /// - Returns : A boolean for weather the imageView is displayed
     func isDisplayedInScreen(_ imageView: NSView?) -> Bool {
-        guard !isHidden, let imageView = imageView else  {
+        guard !isHidden, window != nil, let imageView = imageView else  {
             return false
         }
-        
-        let screenRect = NSScreen.main?.visibleFrame ?? .zero
-        let viewRect = imageView.convert(bounds, to:nil)
-        let intersectionRect = viewRect.intersection(screenRect)
-        
-        return window != nil && !intersectionRect.isEmpty && !intersectionRect.isNull
+
+        for screen in NSScreen.screens {
+          let screenRect = screen.visibleFrame
+          let viewRect = imageView.convert(bounds, to: nil)
+          let intersectionRect = viewRect.intersection(screenRect)
+
+          if !intersectionRect.isEmpty && !intersectionRect.isNull {
+            // The image view is visible on a screen
+            return true
+          }
+        }
+
+        return false
     }
     
     func clear() {


### PR DESCRIPTION
On macOS, the GIF will pause playback due to it not being on the "main" screen (if you drag the app to an external / secondary display, for example). This fixes that by checking if the image view is on any of the attached screens.