### PR TITLE
Fix playback speed on non-60hz displays

### DIFF
--- a/SwiftyGif/UIImage+SwiftyGif.swift
+++ b/SwiftyGif/UIImage+SwiftyGif.swift
@@ -210,27 +210,21 @@ public extension UIImage {
         let levelOfIntegrity = max(0, min(1, levelOfIntegrity))
         var delays = delaysArray
 
-        var displayRefreshFactors = [Int]()
-
-        displayRefreshFactors.append(contentsOf: [60, 30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1])
+        var displayRefreshFactors = [60, 30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1]
         
-        // maxFramePerSecond,default is 60
-        let maxFramePerSecond = displayRefreshFactors[0]
-
-        // frame numbers per second
-        var displayRefreshRates = displayRefreshFactors.map { maxFramePerSecond / $0 }
-
-        if #available(iOS 10.3, *) {
+        if #available(iOS 10.3, tvOS 10.3, *) {
             // Will be 120 on devices with ProMotion display, 60 otherwise.
+            // TODO: Use CADisplayLink to get current framerate. This is still 120 on ProMotion dispays even in low power mode.
             let maximumFramesPerSecond = UIScreen.main.maximumFramesPerSecond
             if maximumFramesPerSecond == 120 {
-                displayRefreshRates.append(maximumFramesPerSecond)
                 displayRefreshFactors.insert(maximumFramesPerSecond, at: 0)
             }
         }
-
+        
+        let maxFramePerSecond = displayRefreshFactors[0]
+        
         // time interval per frame
-        let displayRefreshDelayTime = displayRefreshRates.map { 1 / Float($0) }
+        let displayRefreshDelayTime = displayRefreshFactors.map { Float($0) / Float(maxFramePerSecond) }
         
         // calculate the time when each frame should be displayed at(start at 0)
         for i in delays.indices.dropFirst() {


### PR DESCRIPTION
Fixes #170 and brings back tvOS support. This is a band aid solution to the problem as the playback speed gets slow when my iPad pro is on low power mode.