### PR TITLE
expose PrivacyInfo.xcprivacy file

### DIFF
--- a/SwiftyGif.podspec
+++ b/SwiftyGif.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/kirualex/SwiftyGif.git", :tag => s.version.to_s }
   s.platform     = :ios, '9.0'
   s.requires_arc = true
-  s.source_files = 'SwiftyGif/*{.h,.swift,.xcprivacy}'
+  s.source_files = 'SwiftyGif/*{.h,.swift}'
+  s.resource_bundles = {'SwiftyGif' => ['SwiftyGif/PrivacyInfo.xcprivacy']}
   s.swift_version = '5.0'
 end

--- a/SwiftyGif.podspec
+++ b/SwiftyGif.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/kirualex/SwiftyGif.git", :tag => s.version.to_s }
   s.platform     = :ios, '9.0'
   s.requires_arc = true
-  s.source_files = 'SwiftyGif/*{.h,.swift}'
+  s.source_files = 'SwiftyGif/*{.h,.swift,.xcprivacy}'
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
Adapt to [Apple's requirements](https://developer.apple.com/cn/support/third-party-SDK-requirements/)，it is necessary to include PrivacyInfo.xcprivacy files.

I saw that the file was already included in the SDK, but it was not exposed. 

This PR introduces the support for Cocoapods based projects by adding using resource_bundles in the podspec.

More details on the solution using resource_bundles can be found in this great comment in the Google promises repository, which is working on the same fix:

https://github.com/google/promises/pull/226#discussion_r1447871477