### PR TITLE
Fix PrivacyInfo.xcprivacy

### DIFF
--- a/SwiftyGif/PrivacyInfo.xcprivacy
+++ b/SwiftyGif/PrivacyInfo.xcprivacy
@@ -4,5 +4,11 @@
 <dict>
 	<key>NSPrivacyTracking</key>
 	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
ref: https://github.com/kirualex/SwiftyGif/issues/197

If PrivacyInfo.xcprivacy does not contain NSPrivacyCollectedDataTypes, an error occurs in the privacy report. I have fixed PrivacyInfo.xcprivacy to prevent this error.

![スクリーンショット 2024-03-11 19 46 48](https://github.com/kirualex/SwiftyGif/assets/137952/24c5dd8a-6c17-403c-937b-d1b5e08d0c3c)

### Privacy Report
| before | after |
|:----|:----|
| <img src="https://github.com/kirualex/SwiftyGif/assets/137952/2f5d0b85-3a30-494d-b9e8-88d0169e460e" width="320px" /> | <img src="https://github.com/kirualex/SwiftyGif/assets/137952/620c5628-e7a1-4a58-bdaa-f289efdd2a90" width="320px" /> |
