### PR TITLE
Fix issue with remote images

### DIFF
--- a/SwiftyGif/UIImageView+SwiftyGif.swift
+++ b/SwiftyGif/UIImageView+SwiftyGif.swift
@@ -89,16 +89,6 @@ public extension UIImageView {
 
 public extension UIImageView {
     
-    private static var fileURLKey: UInt8 = 0
-
-     var giffileURL: URL? {
-         get {
-             return objc_getAssociatedObject(self, &UIImageView.fileURLKey) as? URL
-         }
-         set {
-             objc_setAssociatedObject(self, &UIImageView.fileURLKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-         }
-     }
     /// Download gif image and sets it.
     ///
     /// - Parameters:
@@ -187,13 +177,11 @@ public extension UIImageView {
         }
         
         do {
-            if self.giffileURL?.absoluteString == url.absoluteString {
-                let image = try UIImage(gifData: data, levelOfIntegrity: levelOfIntegrity)
-                manager.remoteCache[url] = data
-                setGifImage(image, manager: manager, loopCount: loopCount)
-                startAnimatingGif()
-                delegate?.gifURLDidFinish?(sender: self)
-            }
+            let image = try UIImage(gifData: data, levelOfIntegrity: levelOfIntegrity)
+            manager.remoteCache[url] = data
+            setGifImage(image, manager: manager, loopCount: loopCount)
+            startAnimatingGif()
+            delegate?.gifURLDidFinish?(sender: self)
         } catch {
             report(url: url, error: error)
         }


### PR DESCRIPTION
It seems like #199 has unfortunately introduced a regression with remote images. The example project no longer displays remote gifs.

| Before | After |
|--------|--------|
| ![Before](https://github.com/kirualex/SwiftyGif/assets/2136338/8228149c-a49f-4c6e-acc9-4e8de91a3d79) | ![After](https://github.com/kirualex/SwiftyGif/assets/2136338/94eee9a7-4ea1-4b51-8601-0c7274f91a11) | 
