### PR TITLE
Fix ProMotion display speed

### DIFF
--- a/SwiftyGif/UIImage+SwiftyGif.swift
+++ b/SwiftyGif/UIImage+SwiftyGif.swift
@@ -212,25 +212,27 @@ public extension UIImage {
         var displayRefreshFactors = [Int]()
 
         displayRefreshFactors.append(contentsOf: [60, 30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1])
-        
-        // maxFramePerSecond,default is 60
-        let maxFramePerSecond = displayRefreshFactors[0]
 
-        // frame numbers per second
-        var displayRefreshRates = displayRefreshFactors.map { maxFramePerSecond / $0 }
+        let defaultMaxFramePerSecond = 60
+        var maxFramePerSecond = defaultMaxFramePerSecond
 
         if #available(iOS 10.3, *) {
             // Will be 120 on devices with ProMotion display, 60 otherwise.
             let maximumFramesPerSecond = UIScreen.main.maximumFramesPerSecond
             if maximumFramesPerSecond == 120 {
-                displayRefreshRates.append(maximumFramesPerSecond)
+                maxFramePerSecond = maximumFramesPerSecond
                 displayRefreshFactors.insert(maximumFramesPerSecond, at: 0)
             }
         }
 
+        let frameRateRatio = Float(maxFramePerSecond / defaultMaxFramePerSecond)
+
+        // frame numbers per second
+        let displayRefreshRates = displayRefreshFactors.map { maxFramePerSecond / $0 }
+
         // time interval per frame
-        let displayRefreshDelayTime = displayRefreshRates.map { 1 / Float($0) }
-        
+        let displayRefreshDelayTime = displayRefreshRates.map { frameRateRatio / Float($0) }
+
         // calculate the time when each frame should be displayed at(start at 0)
         for i in delays.indices.dropFirst() {
             delays[i] += delays[i - 1]


### PR DESCRIPTION
Fixes an issue where gifs would play at half speed on ProMotion displays.

`displayRefreshDelayTime[0]` currently evaluates to `1.0` on ProMotion displays. This fix now evaluates it to `2.0`. It remains set to `1.0` on non-ProMotion display devices.

To achieve this, `displayRefreshDelayTime` values now take into account a `frameRateRatio` which is the display's `maximumFramesPerSecond / 60`.

## Results

### On ProMotion Device (iPhone 13 Pro)

| Before | After |
|--------|--------|
| ![Before](https://github.com/kirualex/SwiftyGif/assets/2136338/5be664a1-e1c5-4c17-a381-15f74c78348a) | ![After](https://github.com/kirualex/SwiftyGif/assets/2136338/d3af9781-caad-4d80-9de9-0767c9977f0a) | 

### On Non-ProMotion Device (iPhone 15 Simulator)

| Before | After |
|--------|--------|
|  ![Before](https://github.com/kirualex/SwiftyGif/assets/2136338/5f918621-ab38-49c5-b765-17cceab34db7) | ![After](https://github.com/kirualex/SwiftyGif/assets/2136338/880e87dd-a6fc-4127-b7db-7d2758dd054c) | 
